### PR TITLE
회원가입, 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+/.env

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.5'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
@@ -37,12 +39,13 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.5'
+
     runtimeOnly 'org.postgresql:postgresql'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.5'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  mono_db:
+    image: bitnami/postgresql:latest
+    container_name: mono_db
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: mono_db
+    ports:
+      - 15432:5432
+    volumes:
+      - mono_data:/bitnami/lib/postgresql/data
+    networks:
+      - mono-network
+
+
+volumes:
+  mono_data:
+
+networks:
+  mono-network:
+    name: mono-network
+    driver: bridge

--- a/src/main/java/com/logistics/moolryu/domains/user/controller/UserController.java
+++ b/src/main/java/com/logistics/moolryu/domains/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.logistics.moolryu.domains.user.controller;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.logistics.moolryu.domains.user.controller.dto.LogInRequestDto;
+import com.logistics.moolryu.domains.user.controller.dto.SignUpRequestDto;
+import com.logistics.moolryu.domains.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	@PostMapping("/signup")
+	public ResponseEntity<String> signUp(
+		@RequestBody SignUpRequestDto requestDto
+	) {
+		userService.signUp(requestDto);
+		return ResponseEntity.ok("회원 가입 완료");
+	}
+
+	@PostMapping("/login")
+	public ResponseEntity<String> login(
+		@RequestBody LogInRequestDto requestDto
+	) {
+		String token = userService.login(requestDto);
+		return ResponseEntity.ok()
+			.header(HttpHeaders.AUTHORIZATION, token)
+			.build();
+	}
+}

--- a/src/main/java/com/logistics/moolryu/domains/user/controller/dto/LogInRequestDto.java
+++ b/src/main/java/com/logistics/moolryu/domains/user/controller/dto/LogInRequestDto.java
@@ -1,0 +1,15 @@
+package com.logistics.moolryu.domains.user.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LogInRequestDto {
+
+	private String username;
+	private String password;
+
+}

--- a/src/main/java/com/logistics/moolryu/domains/user/controller/dto/SignUpRequestDto.java
+++ b/src/main/java/com/logistics/moolryu/domains/user/controller/dto/SignUpRequestDto.java
@@ -1,0 +1,16 @@
+package com.logistics.moolryu.domains.user.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpRequestDto {
+
+	private String username;
+	private String password;
+	private String nickname;
+
+}

--- a/src/main/java/com/logistics/moolryu/domains/user/entity/User.java
+++ b/src/main/java/com/logistics/moolryu/domains/user/entity/User.java
@@ -1,0 +1,67 @@
+package com.logistics.moolryu.domains.user.entity;
+
+import com.logistics.moolryu.global.security.user.UserRoleConvertor;
+import com.logistics.moolryu.global.security.user.UserRoleEnum;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "p_user")
+public class User {
+
+	@Id
+	@Tsid
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private String username;
+
+	@Column(nullable = false, unique = true)
+	private String password;
+
+	@Column(nullable = false, unique = true)
+	private String nickName;
+
+	@Column(nullable = false)
+	@Convert(converter = UserRoleConvertor.class)
+	private UserRoleEnum role;
+
+	@Builder
+	private User(String username, String password, String nickName, UserRoleEnum role) {
+		this.username = username;
+		this.password = password;
+		this.nickName = nickName;
+		this.role = role;
+	}
+
+	public static User createUser(String username, String password, String nickName) {
+		return User.builder()
+			.username(username)
+			.password(password)
+			.nickName(nickName)
+			.role(UserRoleEnum.USER)
+			.build();
+	}
+
+	public static User createManager(String username, String password, String nickName, UserRoleEnum role) {
+		return User.builder()
+			.username(username)
+			.password(password)
+			.nickName(nickName)
+			.role(role)
+			.build();
+	}
+}

--- a/src/main/java/com/logistics/moolryu/domains/user/repository/UserRepository.java
+++ b/src/main/java/com/logistics/moolryu/domains/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.logistics.moolryu.domains.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.logistics.moolryu.domains.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+	Optional<User> findByUsername(String username);
+
+	boolean existsByUsername(String username);
+}

--- a/src/main/java/com/logistics/moolryu/domains/user/service/UserService.java
+++ b/src/main/java/com/logistics/moolryu/domains/user/service/UserService.java
@@ -1,0 +1,57 @@
+package com.logistics.moolryu.domains.user.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.logistics.moolryu.domains.user.controller.dto.LogInRequestDto;
+import com.logistics.moolryu.domains.user.controller.dto.SignUpRequestDto;
+import com.logistics.moolryu.domains.user.entity.User;
+import com.logistics.moolryu.domains.user.repository.UserRepository;
+import com.logistics.moolryu.global.exception.CustomException;
+import com.logistics.moolryu.global.exception.ErrorCode;
+import com.logistics.moolryu.global.security.user.UserRoleEnum;
+import com.logistics.moolryu.global.security.util.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtUtil jwtUtil;
+
+	public void signUp(SignUpRequestDto requestDto) {
+		if (userRepository.existsByUsername(requestDto.getUsername())) {
+			throw new CustomException(ErrorCode.ALREADY_EXISTS_USER);
+		}
+
+		String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+
+		User user = User.builder()
+			.username(requestDto.getUsername())
+			.password(encodedPassword)
+			.nickName(requestDto.getNickname())
+			.role(UserRoleEnum.USER)
+			.build();
+
+		userRepository.save(user);
+	}
+
+	public String login(LogInRequestDto requestDto) {
+		User user = userRepository.findByUsername(requestDto.getUsername())
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+			throw new CustomException(ErrorCode.INVALID_PASSWORD);
+		}
+
+		jwtUtil.createToken(user.getUsername());
+
+		return jwtUtil.createToken(user.getUsername());
+	}
+
+
+}
+

--- a/src/main/java/com/logistics/moolryu/domains/user/service/UserService.java
+++ b/src/main/java/com/logistics/moolryu/domains/user/service/UserService.java
@@ -9,7 +9,6 @@ import com.logistics.moolryu.domains.user.entity.User;
 import com.logistics.moolryu.domains.user.repository.UserRepository;
 import com.logistics.moolryu.global.exception.CustomException;
 import com.logistics.moolryu.global.exception.ErrorCode;
-import com.logistics.moolryu.global.security.user.UserRoleEnum;
 import com.logistics.moolryu.global.security.util.JwtUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -29,12 +28,10 @@ public class UserService {
 
 		String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
 
-		User user = User.builder()
-			.username(requestDto.getUsername())
-			.password(encodedPassword)
-			.nickName(requestDto.getNickname())
-			.role(UserRoleEnum.USER)
-			.build();
+		User user = User.createUser(
+				requestDto.getUsername(),
+				encodedPassword,
+				requestDto.getNickname());
 
 		userRepository.save(user);
 	}

--- a/src/main/java/com/logistics/moolryu/global/exception/ErrorCode.java
+++ b/src/main/java/com/logistics/moolryu/global/exception/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
 	EXPIRED_TOKEN(400, "만료된 토큰입니다."),
 	USERNAME_CANNOT_BE_NULL_OR_EMPTY(400, "유저네임은 null 또는 빈 값일 수 없습니다."),
 	INVALID_USERID(400, "유효하지않은 유저ID입니다."),
+	INVALID_PASSWORD(400, "비밀번호가 일치하지 않습니다."),
+	ALREADY_EXISTS_USER(400, "이미 존재하는 사용자입니다."),
 
 	/*  401 UNAUTHORIZED : 인증 안됨  */
 	UNAUTHORIZED(401, "인증되지 않았습니다."),

--- a/src/main/java/com/logistics/moolryu/global/security/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/logistics/moolryu/global/security/config/PasswordEncoderConfig.java
@@ -1,0 +1,22 @@
+package com.logistics.moolryu.global.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		DelegatingPasswordEncoder delegatingPasswordEncoder =
+			(DelegatingPasswordEncoder)PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+		delegatingPasswordEncoder.setDefaultPasswordEncoderForMatches(new BCryptPasswordEncoder());
+
+		return delegatingPasswordEncoder;
+	}
+}

--- a/src/main/java/com/logistics/moolryu/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/logistics/moolryu/global/security/config/SecurityConfig.java
@@ -1,10 +1,55 @@
 package com.logistics.moolryu.global.security.config;
 
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.logistics.moolryu.global.security.filter.JwtAuthorizationFilter;
+import com.logistics.moolryu.global.security.user.UserDetailsServiceImpl;
+import com.logistics.moolryu.global.security.util.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final JwtUtil jwtUtil;
+	private final UserDetailsServiceImpl userDetailsService;
+
+	@Bean
+	public JwtAuthorizationFilter jwtAuthorizationFilter() {
+		return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http.csrf(csrf -> csrf.disable());
+
+		http.sessionManagement(session ->
+			session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+		http.authorizeHttpRequests(auth ->
+			auth
+				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+				.requestMatchers("/api/users/signup", "/api/users/login").permitAll()
+				.anyRequest().authenticated()
+		);
+
+		http.formLogin(form -> form.disable());
+
+		http.addFilterBefore(
+			new JwtAuthorizationFilter(jwtUtil, userDetailsService),
+			UsernamePasswordAuthenticationFilter.class
+		);
+
+		return http.build();
+	}
 
 }

--- a/src/main/java/com/logistics/moolryu/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/logistics/moolryu/global/security/config/SecurityConfig.java
@@ -1,0 +1,10 @@
+package com.logistics.moolryu.global.security.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+}

--- a/src/main/java/com/logistics/moolryu/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/logistics/moolryu/global/security/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,73 @@
+package com.logistics.moolryu.global.security.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.logistics.moolryu.global.security.user.UserDetailsImpl;
+import com.logistics.moolryu.global.security.user.UserDetailsServiceImpl;
+import com.logistics.moolryu.global.security.util.JwtUtil;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JwtAuthorizationFilter  extends OncePerRequestFilter {
+
+	private final JwtUtil jwtUtil;
+	private final UserDetailsServiceImpl userDetailsService;
+
+	public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+		this.jwtUtil = jwtUtil;
+		this.userDetailsService = userDetailsService;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException
+	{
+		String tokenValue = jwtUtil.getTokenFromRequest(request);
+
+		if (StringUtils.hasText(tokenValue)) {
+			tokenValue = jwtUtil.substringToken(tokenValue);
+
+			if (!jwtUtil.validateToken(tokenValue)) {
+				log.error("JWT 토큰 에러");
+				filterChain.doFilter(request, response);
+				return;
+			}
+
+			Claims claims = jwtUtil.getUserInfoFromToken(tokenValue);
+
+			try {
+				setAuthentication(claims.getSubject());
+			} catch (Exception e) {
+				log.error(e.getMessage());
+				filterChain.doFilter(request, response);
+				return;
+			}
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	private void setAuthentication(String username) {
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		Authentication authentication = createAuthentication(username);
+		context.setAuthentication(authentication);
+		SecurityContextHolder.setContext(context);
+	}
+
+	private Authentication createAuthentication(String username) {
+		UserDetailsImpl userDetails = userDetailsService.loadUserByUsername(username);
+		return new UsernamePasswordAuthenticationToken(userDetails.getUser(), null, userDetails.getAuthorities());
+	}
+}

--- a/src/main/java/com/logistics/moolryu/global/security/user/UserDetailsImpl.java
+++ b/src/main/java/com/logistics/moolryu/global/security/user/UserDetailsImpl.java
@@ -1,0 +1,49 @@
+package com.logistics.moolryu.global.security.user;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.logistics.moolryu.domains.user.entity.User;
+
+public class UserDetailsImpl implements UserDetails {
+
+	private final User user;
+
+	public UserDetailsImpl(User user) {
+		this.user = user;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getUsername();
+	}
+
+	public String getRole() {
+		return user.getRole().getAuthority();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		UserRoleEnum role = user.getRole();
+		String authority = role.getAuthority();
+
+		SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(simpleGrantedAuthority);
+
+		return authorities;
+	}
+}

--- a/src/main/java/com/logistics/moolryu/global/security/user/UserDetailsServiceImpl.java
+++ b/src/main/java/com/logistics/moolryu/global/security/user/UserDetailsServiceImpl.java
@@ -1,6 +1,5 @@
 package com.logistics.moolryu.global.security.user;
 
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -19,7 +18,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 	private final UserRepository userRepository;
 
 	@Override
-	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+	public UserDetailsImpl loadUserByUsername(String username) throws UsernameNotFoundException {
 		User user = userRepository.findByUsername(username)
 			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 

--- a/src/main/java/com/logistics/moolryu/global/security/user/UserDetailsServiceImpl.java
+++ b/src/main/java/com/logistics/moolryu/global/security/user/UserDetailsServiceImpl.java
@@ -1,0 +1,28 @@
+package com.logistics.moolryu.global.security.user;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.logistics.moolryu.domains.user.entity.User;
+import com.logistics.moolryu.domains.user.repository.UserRepository;
+import com.logistics.moolryu.global.exception.CustomException;
+import com.logistics.moolryu.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		User user = userRepository.findByUsername(username)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		return new UserDetailsImpl(user);
+	}
+}

--- a/src/main/java/com/logistics/moolryu/global/security/user/UserRoleConvertor.java
+++ b/src/main/java/com/logistics/moolryu/global/security/user/UserRoleConvertor.java
@@ -1,0 +1,19 @@
+package com.logistics.moolryu.global.security.user;
+
+import jakarta.persistence.AttributeConverter;
+
+public class UserRoleConvertor implements AttributeConverter<UserRoleEnum, String> {
+
+	@Override
+	public String convertToDatabaseColumn(UserRoleEnum userRoleEnum) {
+		if (userRoleEnum == null) {
+			return null;
+		}
+		return userRoleEnum.getAuthority();
+	}
+
+	@Override
+	public UserRoleEnum convertToEntityAttribute(String data) {
+		return UserRoleEnum.getInstance(data);
+	}
+}

--- a/src/main/java/com/logistics/moolryu/global/security/user/UserRoleEnum.java
+++ b/src/main/java/com/logistics/moolryu/global/security/user/UserRoleEnum.java
@@ -1,0 +1,43 @@
+package com.logistics.moolryu.global.security.user;
+
+import java.util.Arrays;
+
+public enum UserRoleEnum {
+
+	USER(Authority.USER),
+	MANAGER_USER(Authority.MANAGER_USER),
+	MANAGER_PAYMENT(Authority.MANAGER_PAYMENT),
+	MANAGER_ORDER(Authority.MANAGER_ORDER),
+	MANAGER_PRODUCT(Authority.MANAGER_PRODUCT),
+	MANAGER_DELIVERY(Authority.MANAGER_DELIVERY),
+	MANAGER_HUB(Authority.MANAGER_HUB);
+
+
+	private final String authority;
+
+	UserRoleEnum(String authority) {
+		this.authority = authority;
+	}
+
+	public String getAuthority() {
+		return this.authority;
+	}
+
+	public static UserRoleEnum getInstance(String authority) {
+		return Arrays.stream(values())
+			.filter(role -> role.getAuthority().equals(authority))
+			.findFirst()
+			.orElseThrow();
+	}
+
+	public static class Authority {
+		public static final String USER = "ROLE_USER";
+		public static final String MANAGER_USER = "ROLE_MANAGER_USER";
+		public static final String MANAGER_PAYMENT = "ROLE_MANAGER_PAYMENT";
+		public static final String MANAGER_ORDER = "ROLE_MANAGER_ORDER";
+		public static final String MANAGER_PRODUCT = "ROLE_MANAGER_PRODUCT";
+		public static final String MANAGER_DELIVERY = "ROLE_MANAGER_DELIVERY";
+		public static final String MANAGER_HUB = "ROLE_MANAGER_HUB";
+	}
+
+}

--- a/src/main/java/com/logistics/moolryu/global/security/util/JwtUtil.java
+++ b/src/main/java/com/logistics/moolryu/global/security/util/JwtUtil.java
@@ -1,0 +1,118 @@
+package com.logistics.moolryu.global.security.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.logistics.moolryu.global.security.user.UserRoleEnum;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class JwtUtil {
+
+	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String AUTHORIZATION_KEY = "auth";
+	public static final String BEARER_PREFIX = "Bearer ";
+	private final long TOKEN_TIME = 12 * 60 * 60 * 1000L; // 12시간
+
+	@Value("${jwt.secret.key}")
+	private String secretKey;
+	private Key key;
+
+	@PostConstruct
+	public void init() {
+		byte[] bytes = Base64.getDecoder().decode(secretKey);
+		key = Keys.hmacShaKeyFor(bytes);
+	}
+
+	public String createToken(String username) {
+		Date date = new Date();
+
+		return BEARER_PREFIX +
+			Jwts.builder()
+				.subject(username)
+				.claim(AUTHORIZATION_KEY, UserRoleEnum.USER)
+				.expiration(new Date(date.getTime() + TOKEN_TIME))
+				.issuedAt(date)
+				.signWith(key)
+				.compact();
+	}
+
+	public String createAdminToken(String username, UserRoleEnum role) {
+		Date date = new Date();
+
+		return BEARER_PREFIX +
+			Jwts.builder()
+				.subject(username)
+				.claim(AUTHORIZATION_KEY, role)
+				.expiration(new Date(date.getTime() + TOKEN_TIME))
+				.issuedAt(date)
+				.signWith(key)
+				.compact();
+	}
+
+	public void addJwtToCookie(String token, HttpServletResponse response) {
+		try {
+			token = URLEncoder.encode(token, "utf-8").replaceAll("\\+", "%20");
+
+			Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token);
+			cookie.setPath("/");
+
+			response.addCookie(cookie);
+			response.setHeader("ACCESS_TOKEN", token);
+		} catch (UnsupportedEncodingException e) {
+			log.error(e.getMessage());
+		}
+	}
+
+	public String substringToken(String tokenValue) {
+		if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+			return tokenValue.substring(7);
+		}
+		log.error("Not Found Token");
+		throw new NullPointerException("Not Found Token");
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parser().verifyWith((SecretKey)key).build().parseSignedClaims(token);
+		} catch (SecurityException | MalformedJwtException e) {
+			log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+		} catch (ExpiredJwtException e) {
+			log.error("Expired JWT token, 만료된 JWT token 입니다.");
+		} catch (UnsupportedJwtException e) {
+			log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+		} catch (IllegalArgumentException e) {
+			log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+		}
+		return false;
+	}
+
+	public Claims getUserInfoFromToken(String token) {
+		return Jwts.parser().verifyWith((SecretKey)key).build().parseSignedClaims(token).getPayload();
+	}
+
+	public String getTokenFromRequest(HttpServletRequest request) {
+		return request.getHeader("Authorization");
+	}
+}

--- a/src/main/java/com/logistics/moolryu/global/security/util/JwtUtil.java
+++ b/src/main/java/com/logistics/moolryu/global/security/util/JwtUtil.java
@@ -1,7 +1,7 @@
 package com.logistics.moolryu.global.security.util;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
@@ -72,17 +72,13 @@ public class JwtUtil {
 	}
 
 	public void addJwtToCookie(String token, HttpServletResponse response) {
-		try {
-			token = URLEncoder.encode(token, "utf-8").replaceAll("\\+", "%20");
+		token = URLEncoder.encode(token, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
 
-			Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token);
-			cookie.setPath("/");
+		Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token);
+		cookie.setPath("/");
 
-			response.addCookie(cookie);
-			response.setHeader("ACCESS_TOKEN", token);
-		} catch (UnsupportedEncodingException e) {
-			log.error(e.getMessage());
-		}
+		response.addCookie(cookie);
+		response.setHeader("ACCESS_TOKEN", token);
 	}
 
 	public String substringToken(String tokenValue) {

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -1,0 +1,2 @@
+spring:
+  datasource:

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -1,2 +1,16 @@
 spring:
   datasource:
+    url: ${MONO_DB_URL}
+    username: ${MONO_DB_USER}
+    password: ${MONO_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    open-in-view: false

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -1,0 +1,3 @@
+spring:
+  jwt:
+    secret: ${jwt.secret.key}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
 spring:
   application:
     name: Mool-Ryu
+
+  profiles:
+    include: datasource, jwt


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cc32ac87-6cdd-48bb-ad63-fcfebd650c1a)


> 특이사항
1. 컨트롤러에서 회원가입, 로그인 구현해서 인증 필터 없음
2. 단순히 비크립트를 리턴하는 대신 DelegatingPasswordEncoder 사용
3. 빌더만 쓰기 귀찮아서 빌더 + 팩토리메서드 사용
4. 도커컴포즈 넣어둠.   모놀리식이니까 이름 mono_db 로 함
5. **.env는 깃이그노어에 박고 공유안함. 알아서 만들어서 쓰도록**
</br></br>
> 추후 구현 사항
1. 스프링 밸리데이션으로  아이디, 비밀번호 dto에서 검증하기
2. 관리자 회원가입 구현
</br></br>
확인하는 사람이 머지하기